### PR TITLE
Add basic HRTB updates web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-cat > .gitignore << 'EOF'
 # Node & Reveal build artifacts
 node_modules/
 .DS_Store
@@ -8,4 +7,3 @@ __pycache__/
 
 # Mac/Linux temp files
 *~
-EOF

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
-# HRT-B_app
-# HRT-B_app
+# HRT-B App
+
+Simple static site that displays Human Rights Treaty Body (HRTB) updates.
+
+## Development
+
+1. Install Node.js (v18+).
+2. Start the development server:
+
+```bash
+npm start
+```
+
+The site will be available at `http://localhost:3000`.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const container = document.getElementById('dynamic-updates');
+  if (!container) return;
+
+  try {
+    const response = await fetch('updates.json');
+    const updates = await response.json();
+    container.innerHTML = '';
+    updates.forEach(update => {
+      const div = document.createElement('div');
+      div.className = 'p-6 bg-white shadow-lg rounded-lg space-y-1';
+      const date = new Date(update.date).toLocaleDateString();
+      div.innerHTML = `\n        <p class="text-sm text-gray-500">${date}</p>\n        <h4 class="text-xl font-semibold">${update.title}</h4>\n        <p>${update.summary}</p>\n      `;
+      container.appendChild(div);
+    });
+  } catch (err) {
+    console.error('Failed to load updates', err);
+    container.innerHTML = '<p class="text-red-600">Failed to load updates.</p>';
+  }
+});

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
       <nav class="space-x-6">
         <a href="#what" class="hover:text-blue-600">What is HRTB?</a>
         <a href="#reports" class="hover:text-blue-600">Latest Reports</a>
+        <a href="#latest" class="hover:text-blue-600">Latest Updates</a>
         <a href="#sessions" class="hover:text-blue-600">Upcoming Sessions</a>
         <a href="#subscribe" class="hover:text-blue-600">Subscribe</a>
       </nav>
@@ -77,6 +78,14 @@
             <li>Improve access to disaggregated data</li>
           </ul>
         </div>
+      </div>
+    </section>
+
+    <!-- Latest Updates -->
+    <section id="latest" class="max-w-4xl mx-auto px-4">
+      <h3 class="text-3xl font-bold mb-6 text-center">Latest HRTB Updates</h3>
+      <div id="dynamic-updates" class="space-y-8">
+        <p class="text-center text-gray-500">Loading updates...</p>
       </div>
     </section>
 
@@ -141,5 +150,6 @@
     </div>
   </footer>
 
+<script src="app.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "hrt-b_app",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"No tests specified\"",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,41 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = process.env.PORT || 3000;
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml'
+};
+
+http.createServer((req, res) => {
+  let filePath = '.' + decodeURI(req.url);
+  if (filePath === './') filePath = './index.html';
+
+  const ext = path.extname(filePath).toLowerCase();
+  const contentType = mimeTypes[ext] || 'application/octet-stream';
+
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      if (err.code === 'ENOENT') {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('404 Not Found');
+      } else {
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Server Error');
+      }
+    } else {
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(content, 'utf-8');
+    }
+  });
+}).listen(port, () => {
+  console.log(`Server running at http://localhost:${port}/`);
+});

--- a/updates.json
+++ b/updates.json
@@ -1,0 +1,12 @@
+[
+  {
+    "date": "2025-06-01",
+    "title": "New guidance on climate justice",
+    "summary": "HRTB issued new guidance on integrating climate justice in monitoring."
+  },
+  {
+    "date": "2025-05-20",
+    "title": "Committee highlights digital rights",
+    "summary": "Digital rights featured prominently in the latest session discussions."
+  }
+]


### PR DESCRIPTION
## Summary
- show latest HRTB updates from JSON
- fetch and render updates via `app.js`
- serve static site using a simple Node server
- provide start script and usage instructions

## Testing
- `npm test`
- `npm start` (started server briefly)

------
https://chatgpt.com/codex/tasks/task_e_684816dc02d48320b4e19144afdba93b