### PR TITLE
Enhance page with dataset and OHCHR style

### DIFF
--- a/data_sample.json
+++ b/data_sample.json
@@ -1,0 +1,203 @@
+[
+  {
+    "ReportingCycle": "CERD",
+    "TreatyCode": "Palestine",
+    "CountryName": "Concluding observations",
+    "DocumentType": "-1",
+    "DueDate": "20190828",
+    "SubmitDate": "20190920",
+    "PublicationDate": "CERD/C/PSE/CO/1-2",
+    "Symbol_No": "http://tbinternet.ohchr.org/_layouts/treatybodyexternal/Download.aspx?symbolno=CERD/C/PSE/CO/1-2"
+  },
+  {
+    "ReportingCycle": "CEDAW",
+    "TreatyCode": "Palestine",
+    "CountryName": "Concluding observations",
+    "DocumentType": "-1",
+    "DueDate": "-1",
+    "SubmitDate": "20180725",
+    "PublicationDate": "CEDAW/C/PSE/CO/1",
+    "Symbol_No": "http://tbinternet.ohchr.org/_layouts/treatybodyexternal/Download.aspx?symbolno=CEDAW/C/PSE/CO/1"
+  },
+  {
+    "ReportingCycle": "CAT",
+    "TreatyCode": "Palestine",
+    "CountryName": "Concluding observations",
+    "DocumentType": "-1",
+    "DueDate": "20220729",
+    "SubmitDate": "20220823",
+    "PublicationDate": "CAT/C/PSE/CO/1",
+    "Symbol_No": "http://tbinternet.ohchr.org/_layouts/treatybodyexternal/Download.aspx?symbolno=CAT/C/PSE/CO/1"
+  },
+  {
+    "ReportingCycle": "CRC",
+    "TreatyCode": "Palestine",
+    "CountryName": "Concluding observations",
+    "DocumentType": "-1",
+    "DueDate": "20200207",
+    "SubmitDate": "20200306",
+    "PublicationDate": "CRC/C/PSE/CO/1",
+    "Symbol_No": "http://tbinternet.ohchr.org/_layouts/treatybodyexternal/Download.aspx?symbolno=CRC/C/PSE/CO/1"
+  },
+  {
+    "ReportingCycle": "CAT",
+    "TreatyCode": "Palestine",
+    "CountryName": "State party's report",
+    "DocumentType": "20150502",
+    "DueDate": "20190614",
+    "SubmitDate": "20190826",
+    "PublicationDate": "CAT/C/PSE/1",
+    "Symbol_No": "http://tbinternet.ohchr.org/_layouts/treatybodyexternal/Download.aspx?symbolno=CAT/C/PSE/1"
+  },
+  {
+    "ReportingCycle": "CCPR",
+    "TreatyCode": "Palestine",
+    "CountryName": "State party's report",
+    "DocumentType": "20150702",
+    "DueDate": "20201116",
+    "SubmitDate": "20210826",
+    "PublicationDate": "CCPR/C/PSE/1",
+    "Symbol_No": "http://tbinternet.ohchr.org/_layouts/treatybodyexternal/Download.aspx?symbolno=CCPR/C/PSE/1"
+  },
+  {
+    "ReportingCycle": "CCPR",
+    "TreatyCode": "Palestine",
+    "CountryName": "List of issues",
+    "DocumentType": "-1",
+    "DueDate": "-1",
+    "SubmitDate": "20220919",
+    "PublicationDate": "CCPR/C/PSE/Q/1",
+    "Symbol_No": "http://tbinternet.ohchr.org/_layouts/treatybodyexternal/Download.aspx?symbolno=CCPR/C/PSE/Q/1"
+  },
+  {
+    "ReportingCycle": "CCPR",
+    "TreatyCode": "Palestine",
+    "CountryName": "Reply to List of Issues",
+    "DocumentType": "-1",
+    "DueDate": "20230406",
+    "SubmitDate": "20230501",
+    "PublicationDate": "CCPR/C/PSE/RQ/1",
+    "Symbol_No": "http://tbinternet.ohchr.org/_layouts/treatybodyexternal/Download.aspx?symbolno=CCPR/C/PSE/RQ/1"
+  },
+  {
+    "ReportingCycle": "CEDAW",
+    "TreatyCode": "Palestine",
+    "CountryName": "State party's report",
+    "DocumentType": "20150502",
+    "DueDate": "20170310",
+    "SubmitDate": "20170524",
+    "PublicationDate": "CEDAW/C/PSE/1",
+    "Symbol_No": "http://tbinternet.ohchr.org/_layouts/treatybodyexternal/Download.aspx?symbolno=CEDAW/C/PSE/1"
+  },
+  {
+    "ReportingCycle": "CEDAW",
+    "TreatyCode": "Palestine",
+    "CountryName": "State Party report on Follow-up to Concluding Observations",
+    "DocumentType": "-1",
+    "DueDate": "20200727",
+    "SubmitDate": "20200819",
+    "PublicationDate": "CEDAW/C/PSE/FCO/1",
+    "Symbol_No": "http://tbinternet.ohchr.org/_layouts/treatybodyexternal/Download.aspx?symbolno=CEDAW/C/PSE/FCO/1"
+  },
+  {
+    "ReportingCycle": "CEDAW",
+    "TreatyCode": "Palestine",
+    "CountryName": "List of issues",
+    "DocumentType": "-1",
+    "DueDate": "20171124",
+    "SubmitDate": "20171130",
+    "PublicationDate": "CEDAW/C/PSE/Q/1",
+    "Symbol_No": "http://tbinternet.ohchr.org/_layouts/treatybodyexternal/Download.aspx?symbolno=CEDAW/C/PSE/Q/1"
+  },
+  {
+    "ReportingCycle": "CEDAW",
+    "TreatyCode": "Palestine",
+    "CountryName": "Reply to List of Issues",
+    "DocumentType": "-1",
+    "DueDate": "20180219",
+    "SubmitDate": "20180307",
+    "PublicationDate": "CEDAW/C/PSE/Q/1/Add.1",
+    "Symbol_No": "http://tbinternet.ohchr.org/_layouts/treatybodyexternal/Download.aspx?symbolno=CEDAW/C/PSE/Q/1/Add.1"
+  },
+  {
+    "ReportingCycle": "CEDAW",
+    "TreatyCode": "Palestine",
+    "CountryName": "List of issues prior to reporting (LoIPR)",
+    "DocumentType": "-1",
+    "DueDate": "20221102",
+    "SubmitDate": "20221104",
+    "PublicationDate": "CEDAW/C/PSE/QPR/2",
+    "Symbol_No": "http://tbinternet.ohchr.org/_layouts/treatybodyexternal/Download.aspx?symbolno=CEDAW/C/PSE/QPR/2",
+    "DownloadLink": "43900"
+  },
+  {
+    "ReportingCycle": "CERD",
+    "TreatyCode": "Palestine",
+    "CountryName": "State party's report",
+    "DocumentType": "20170502",
+    "DueDate": "20180321",
+    "SubmitDate": "20180914",
+    "PublicationDate": "CERD/C/PSE/1-2",
+    "Symbol_No": "http://tbinternet.ohchr.org/_layouts/treatybodyexternal/Download.aspx?symbolno=CERD/C/PSE/1-2"
+  },
+  {
+    "ReportingCycle": "CERD",
+    "TreatyCode": "Palestine",
+    "CountryName": "State Party report on Follow-up to Concluding Observations",
+    "DocumentType": "-1",
+    "DueDate": "20200922",
+    "SubmitDate": "20201028",
+    "PublicationDate": "CERD/C/PSE/FCO/1-2",
+    "Symbol_No": "http://tbinternet.ohchr.org/_layouts/treatybodyexternal/Download.aspx?symbolno=CERD/C/PSE/FCO/1-2"
+  },
+  {
+    "ReportingCycle": "CERD",
+    "TreatyCode": "Palestine",
+    "CountryName": "List of themes",
+    "DocumentType": "-1",
+    "DueDate": "20190621",
+    "SubmitDate": "20190620",
+    "PublicationDate": "CERD/C/PSE/Q/1-2",
+    "Symbol_No": "http://tbinternet.ohchr.org/_layouts/treatybodyexternal/Download.aspx?symbolno=CERD/C/PSE/Q/1-2"
+  },
+  {
+    "ReportingCycle": "CRC",
+    "TreatyCode": "Palestine",
+    "CountryName": "State party's report",
+    "DocumentType": "20160502",
+    "DueDate": "20180921",
+    "SubmitDate": "20190325",
+    "PublicationDate": "CRC/C/PSE/1",
+    "Symbol_No": "http://tbinternet.ohchr.org/_layouts/treatybodyexternal/Download.aspx?symbolno=CRC/C/PSE/1"
+  },
+  {
+    "ReportingCycle": "CRC",
+    "TreatyCode": "Palestine",
+    "CountryName": "List of issues",
+    "DocumentType": "-1",
+    "DueDate": "20190607",
+    "SubmitDate": "20190705",
+    "PublicationDate": "CRC/C/PSE/Q/1",
+    "Symbol_No": "http://tbinternet.ohchr.org/_layouts/treatybodyexternal/Download.aspx?symbolno=CRC/C/PSE/Q/1"
+  },
+  {
+    "ReportingCycle": "CRC",
+    "TreatyCode": "Palestine",
+    "CountryName": "Reply to List of Issues",
+    "DocumentType": "-1",
+    "DueDate": "20191015",
+    "SubmitDate": "20191125",
+    "PublicationDate": "CRC/C/PSE/RQ/1",
+    "Symbol_No": "http://tbinternet.ohchr.org/_layouts/treatybodyexternal/Download.aspx?symbolno=CRC/C/PSE/RQ/1"
+  },
+  {
+    "ReportingCycle": "CRPD",
+    "TreatyCode": "Palestine",
+    "CountryName": "State party's report",
+    "DocumentType": "20160502",
+    "DueDate": "20190614",
+    "SubmitDate": "20191029",
+    "PublicationDate": "CRPD/C/PSE/1",
+    "Symbol_No": "http://tbinternet.ohchr.org/_layouts/treatybodyexternal/Download.aspx?symbolno=CRPD/C/PSE/1"
+  }
+]

--- a/index.html
+++ b/index.html
@@ -6,24 +6,29 @@
   <title>HRTB Updates</title>
   <!-- Tailwind via CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
-  <!-- Hero background -->
+  <!-- Google font for a professional look -->
+  <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600&display=swap" rel="stylesheet">
+  <!-- Hero background and custom palette -->
   <style>
     .hero-bg {
       background: url('https://images.unsplash.com/photo-1591856977188-36f22f13c590?ixlib=rb-4.0.3&auto=format&fit=crop&w=1950&q=80') center/cover no-repeat;
     }
+    body { font-family: 'Open Sans', sans-serif; }
+    .ohchr-blue { background-color: #005aa9; }
+    .text-ohchr { color: #005aa9; }
   </style>
 </head>
 <body class="font-sans antialiased text-gray-800">
 
   <!-- Navbar -->
-  <header class="fixed w-full bg-white/70 backdrop-blur z-50">
-    <div class="max-w-4xl mx-auto flex justify-between items-center p-4">
-      <h1 class="text-xl font-bold">HRTB Updates</h1>
+  <header class="fixed w-full ohchr-blue text-white/90 backdrop-blur z-50">
+    <div class="max-w-5xl mx-auto flex justify-between items-center p-4">
+      <h1 class="text-xl font-semibold">Human Rights Treaty Bodies</h1>
       <nav class="space-x-6">
-        <a href="#what" class="hover:text-blue-600">What is HRTB?</a>
-        <a href="#reports" class="hover:text-blue-600">Latest Reports</a>
-        <a href="#sessions" class="hover:text-blue-600">Upcoming Sessions</a>
-        <a href="#subscribe" class="hover:text-blue-600">Subscribe</a>
+        <a href="#what" class="text-white hover:underline">What is HRTB?</a>
+        <a href="#reports" class="text-white hover:underline">Latest Reports</a>
+        <a href="#sessions" class="text-white hover:underline">Upcoming Sessions</a>
+        <a href="#subscribe" class="text-white hover:underline">Subscribe</a>
       </nav>
     </div>
   </header>
@@ -116,6 +121,26 @@
       </div>
     </section>
 
+    <!-- Recent Treaty Documents from dataset -->
+    <section id="documents" class="max-w-5xl mx-auto px-4">
+      <h3 class="text-3xl font-bold mb-6 text-center text-ohchr">Recent Treaty Body Documents</h3>
+      <div class="overflow-x-auto shadow ring-1 ring-gray-200 rounded-lg">
+        <table class="min-w-full divide-y divide-gray-300 text-sm" id="dataset-table">
+          <thead class="bg-gray-50">
+            <tr>
+              <th class="p-2 text-left">Treaty</th>
+              <th class="p-2 text-left">Country</th>
+              <th class="p-2 text-left">Type</th>
+              <th class="p-2 text-left">Submit</th>
+              <th class="p-2 text-left">Published</th>
+              <th class="p-2 text-left">Link</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </section>
+
     <!-- Subscribe -->
     <section id="subscribe" class="max-w-2xl mx-auto px-4 text-center">
       <h3 class="text-3xl font-bold mb-4">Stay Informed</h3>
@@ -140,6 +165,25 @@
       <p>Built by Alper Bektaş</p>
     </div>
   </footer>
+
+  <script>
+    fetch('data_sample.json')
+      .then(r => r.json())
+      .then(data => {
+        const tbody = document.querySelector('#dataset-table tbody');
+        data.forEach(rec => {
+          const tr = document.createElement('tr');
+          tr.innerHTML = `
+            <td class="border-b p-2">${rec.ReportingCycle}</td>
+            <td class="border-b p-2">${rec.TreatyCode}</td>
+            <td class="border-b p-2">${rec.CountryName}</td>
+            <td class="border-b p-2">${rec.SubmitDate}</td>
+            <td class="border-b p-2">${rec.PublicationDate}</td>
+            <td class="border-b p-2"><a href="${rec.Symbol_No}" class="text-blue-600 underline" target="_blank">View</a></td>`;
+          tbody.appendChild(tr);
+        });
+      });
+  </script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a sample JSON file extracted from `data.xlsx`
- restyle page header with OHCHR-inspired colours and fonts
- show a table of recent treaty body documents
- load JSON data via a script and populate the table

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68481af589b88320bf0f4d6da7f3da46